### PR TITLE
Fix broken performance link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ Documentation
 
 [FlashGraphR Quick Start](https://github.com/icoming/FlashGraph/wiki/FlashGraphR-Quick-Start-Guide)
 
-[FlashGraph performance](https://github.com/icoming/FlashGraph/wiki/Performance-of-FlashGraph)
+[FlashGraph performance](https://github.com/icoming/FlashGraph/wiki/FlashGraph-performance)
 
 [SAFS user manual](https://github.com/icoming/FlashGraph/wiki/SAFS-user-manual).
 


### PR DESCRIPTION
At some point the link for FlashGraph performance broke, which is especially sad as it's one of the coolest selling points ;)
