### PR TITLE
use python2 instead of python3 for jupyter notebooks

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -53,10 +53,10 @@ RUN ./install_FlashGraphR.sh
 
 ####R finished####
 
-RUN apt-get install -y python3-pip
+RUN apt-get install -y python-pip
 RUN apt-get install -y libcurl4-openssl-dev libssl-dev
-RUN pip3 install --upgrade pip
-RUN pip3 install jupyter
+RUN pip install --upgrade pip
+RUN pip install jupyter
 RUN R -e "install.packages(c('repr', 'IRdisplay', 'evaluate', 'crayon', 'pbdZMQ', 'devtools', 'uuid', 'digest'), repos = 'http://cran.rstudio.com/')"
 RUN R -e "devtools::install_github('IRkernel/IRkernel')"
 RUN R -e "IRkernel::installspec()"


### PR DESCRIPTION
both FlashX and NDMG use python2 and not python3, so it makes sense to support python2 in the notebooks themselves. Please check with a real example; I did not have "test" data for FlashX so I can only guarantee that it builds properly. 